### PR TITLE
Add task_id support for memory entries

### DIFF
--- a/.agent_memory/README.md
+++ b/.agent_memory/README.md
@@ -9,8 +9,12 @@ Agents should review the most recent relevant entries before modifying files and
 Use `.agent_memory/memory_cli.py add` to append a new memory record after each run:
 
 ```bash
-.agent_memory/memory_cli.py add "<context>" "<observation>" "<reflection>" --tags tag1 tag2 --memory-dir .agent_memory
+.agent_memory/memory_cli.py add "<context>" "<observation>" "<reflection>" \
+  --tags tag1 tag2 --task-id <task_id> --memory-dir .agent_memory
 ```
+
+If the entry relates to a tracked task, supply `--task-id` with the task's ID so
+the memory record links back to the task list. This field is optional.
 
 All memory entries must conform to `schema.json`. `.agent_memory/memory_cli.py add`
 loads this schema and validates each record before writing it. The query and

--- a/.agent_memory/add_memory_entry.py
+++ b/.agent_memory/add_memory_entry.py
@@ -26,6 +26,7 @@ def main() -> None:
     parser.add_argument("observation", help="Summary of the outcome")
     parser.add_argument("reflection", help="What to improve next time")
     parser.add_argument("--tags", nargs="*", default=[], help="Optional tags")
+    parser.add_argument("--task-id", help="ID of related task")
     parser.add_argument(
         "--memory-dir",
         type=Path,
@@ -48,6 +49,8 @@ def main() -> None:
         "reflection": args.reflection,
         "tags": args.tags,
     }
+    if args.task_id:
+        entry["task_id"] = args.task_id
 
     schema = load_schema(schema_path)
     validate(instance=entry, schema=schema)

--- a/.agent_memory/entries/2025-05-26T16:45:41.405864.jsonl
+++ b/.agent_memory/entries/2025-05-26T16:45:41.405864.jsonl
@@ -1,0 +1,1 @@
+{"ts": "2025-05-26T16:45:41.405864", "agent": "codex", "run_id": "e20de546-d855-47a9-9845-7f317621308d", "context": "Add task_id support in memory layer", "observation": "Updated schema, CLI, docs, and tests", "reflection": "jsonschema not installed in environment", "tags": ["update"], "task_id": "test"}

--- a/.agent_memory/memory_cli.py
+++ b/.agent_memory/memory_cli.py
@@ -32,6 +32,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     add_p.add_argument("observation")
     add_p.add_argument("reflection")
     add_p.add_argument("--tags", nargs="*", default=[])
+    add_p.add_argument("--task-id", help="ID of related task")
     add_p.add_argument("--memory-dir", type=Path, default=DEFAULT_MEMORY_DIR)
 
     query_p = sub.add_parser("query", help="Query memory entries")
@@ -96,6 +97,8 @@ def handle_add(args: argparse.Namespace) -> None:
         "reflection": args.reflection,
         "tags": args.tags,
     }
+    if args.task_id:
+        entry["task_id"] = args.task_id
 
     schema = add_mod.load_schema(schema_path)
     validate(instance=entry, schema=schema)

--- a/.agent_memory/schema.json
+++ b/.agent_memory/schema.json
@@ -9,7 +9,8 @@
     "context": {"type": "string", "description": "short description of files or task"},
     "observation": {"type": "string", "description": "summary of outcome"},
     "reflection": {"type": "string", "description": "what to improve next time"},
-    "tags": {"type": "array", "items": {"type": "string"}}
+    "tags": {"type": "array", "items": {"type": "string"}},
+    "task_id": {"type": "string", "description": "ID of related task"}
   },
   "required": ["ts", "agent", "run_id", "context", "observation", "reflection"],
   "additionalProperties": false

--- a/.agent_memory/tests/test_memory_cli.py
+++ b/.agent_memory/tests/test_memory_cli.py
@@ -1,0 +1,67 @@
+import json
+import shutil
+from pathlib import Path
+import tempfile
+
+import pytest
+
+# Import modules
+import importlib.util
+
+root = Path(__file__).resolve().parents[1]
+spec_cli = importlib.util.spec_from_file_location('memory_cli', root / 'memory_cli.py')
+memory_cli = importlib.util.module_from_spec(spec_cli)
+spec_cli.loader.exec_module(memory_cli)
+
+spec_add = importlib.util.spec_from_file_location('add_memory_entry', root / 'add_memory_entry.py')
+add_entry = importlib.util.module_from_spec(spec_add)
+spec_add.loader.exec_module(add_entry)
+
+SCHEMA_PATH = Path(__file__).resolve().parents[1] / 'schema.json'
+
+with SCHEMA_PATH.open() as f:
+    SCHEMA = json.load(f)
+
+try:
+    from jsonschema import validate
+except Exception:  # pragma: no cover
+    validate = None
+
+@pytest.mark.skipif(validate is None, reason="jsonschema not installed")
+def test_schema_optional_task_id():
+    base = {
+        "ts": "2025-05-27T00:00:00",
+        "agent": "test",
+        "run_id": "1",
+        "context": "ctx",
+        "observation": "obs",
+        "reflection": "refl",
+        "tags": [],
+    }
+    # should validate without task_id
+    validate(instance=base, schema=SCHEMA)
+    base["task_id"] = "abc"
+    validate(instance=base, schema=SCHEMA)
+
+@pytest.mark.skipif(validate is None, reason="jsonschema not installed")
+def test_cli_add_with_and_without_task_id(tmp_path):
+    memory_dir = tmp_path
+    shutil.copy(SCHEMA_PATH, memory_dir / 'schema.json')
+
+    memory_cli.main([
+        'add', 'ctx', 'obs', 'refl', '--task-id', 'tid', '--memory-dir', str(memory_dir)
+    ])
+    files = list((memory_dir / 'entries').glob('*.jsonl'))
+    assert len(files) == 1
+    with files[0].open() as f:
+        entry = json.loads(f.readline())
+    assert entry['task_id'] == 'tid'
+
+    memory_cli.main([
+        'add', 'ctx2', 'obs2', 'refl2', '--memory-dir', str(memory_dir)
+    ])
+    files = sorted((memory_dir / 'entries').glob('*.jsonl'))
+    assert len(files) == 2
+    with files[1].open() as f:
+        entry = json.loads(f.readline())
+    assert 'task_id' not in entry

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,10 +36,12 @@ The Agent Memory Layer, located in the `.agent_memory/` directory, is a dedicate
 
 * **Add a New Memory Entry:** Log what you did, what the outcome was, and any learnings.
     ```bash
-    python .agent_memory/memory_cli.py add "Brief context of the task" "Summary of what was done/observed" "Reflections or what to improve next time" --tags "relevant_tag" "another_tag"
+    python .agent_memory/memory_cli.py add "Brief context of the task" \
+      "Summary of what was done/observed" "Reflections or what to improve next time" \
+      --tags "relevant_tag" "another_tag" --task-id <task_id>
     ```
     * This creates a timestamped JSONL entry in `.agent_memory/entries/`.
-    * Entries include `ts` (timestamp), `agent`, `run_id`, `context`, `observation`, `reflection`, and `tags`.
+    * Entries include `ts` (timestamp), `agent`, `run_id`, `context`, `observation`, `reflection`, `tags`, and optionally `task_id` linking to a task.
     * Memory entries are validated against `.agent_memory/schema.json`.
 * **Update Task Status:** Mark your current task appropriately (e.g., "finished").
     ```bash

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Refer to the "Agent Guide: Using the Agent Memory Layer" section in your project
     * List tasks: `python .agent_memory/memory_cli.py task list`
     * List notes: `python .agent_memory/memory_cli.py note list`
 2.  **After completing a task:**
-    * Add memory entry: `python .agent_memory/memory_cli.py add "Context" "Observation" "Reflection" --tags "example"`
+    * Add memory entry: `python .agent_memory/memory_cli.py add "Context" "Observation" "Reflection" --tags "example" --task-id <task_id>`
     * Update task status: `python .agent_memory/memory_cli.py task update <id> --status "finished"`
     * Add notes if needed: `python .agent_memory/memory_cli.py note add "Useful persistent info"`
 


### PR DESCRIPTION
## Summary
- support optional task_id in schema
- allow memory_cli.py and add_memory_entry.py to set --task-id
- document linking memory entries to tasks
- add tests for schema and CLI behaviour
- add memory entry for this change

## Testing
- `pytest -q .agent_memory/tests/test_memory_cli.py` *(fails: ModuleNotFoundError: No module named 'jsonschema')*